### PR TITLE
Fix issue with login redirect persistence after failed token attempt.

### DIFF
--- a/django_mfa/tests.py
+++ b/django_mfa/tests.py
@@ -41,3 +41,11 @@ class Views_test(TestCase):
 
     #     self.assertEquals(response.context['error_message'], 'Missing verification code.')
     #     self.assertEquals(response.status_code, 400)
+
+    def test_login_redirect_persists_after_failed_otp_verify(self):
+        login_redirect = '/some_other_url'
+        UserOTP.objects.create(user=self.user, otp_type='totp')
+        response = self.client.post(reverse('mfa:verify_otp'), {'verification_code': 'Bad Code',  'next': login_redirect })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(login_redirect in response.content)

--- a/django_mfa/views.py
+++ b/django_mfa/views.py
@@ -147,6 +147,7 @@ def verify_otp(request):
 
     if request.method == "POST":
         verification_code = request.POST.get('verification_code')
+        ctx['next'] = request.POST.get("next", settings.LOGIN_REDIRECT_URL)
 
         if verification_code is None:
             ctx['error_message'] = "Missing verification code."
@@ -161,6 +162,7 @@ def verify_otp(request):
                 response = redirect(request.POST.get("next", settings.LOGIN_REDIRECT_URL))
                 return update_rmb_cookie(request, response)
             ctx['error_message'] = "Your code is expired or invalid."
+    else:
+        ctx['next'] = request.GET.get('next', settings.LOGIN_REDIRECT_URL)
 
-    ctx['next'] = request.GET.get('next', settings.LOGIN_REDIRECT_URL)
     return render(request, 'django_mfa/login_verify.html', ctx, status=400)


### PR DESCRIPTION
The verify_otp view relies on the get or post param 'next' to store
a redirect url that can override the default settings.LOGIN_REDIRECT_URL.

Upon a failed post it would attempt to pull the next param
from a request GET, which of course there is none.  This caused the
next param to reset to the default settings.LOGIN_REDIRECT_URL after
a failed post.